### PR TITLE
mongo user bug fixed

### DIFF
--- a/frontend/src/components/authContext.js
+++ b/frontend/src/components/authContext.js
@@ -73,12 +73,23 @@ export const AuthProvider = ({ children }) => {
 
             if(user){
                 setUser(user)
+                try {
+                    const firebase_id = user.uid;
+                    const result = await getUser(firebase_id);
+                    setMongoUser(result.user);
+                } catch (error) {
+                    console.log("error refreshing userdetails from mongoDB ", error)
+                } 
+            } else {
+                setUser(null)
+                setMongoUser(null)
                 setIsFetching(false)
                 return
             }
-
-            setUser(null)
+            
             setIsFetching(false)
+
+            
         })
         // unsubcribe is a cleaunup function ensures listener is detached when the componenet is not in use
         return () => unsubscribe()


### PR DESCRIPTION
on refresh mongoUser was being set to null in authContext
now on refresh to state of mongoUser is updated from the DB using the firebase_id of the logged in user